### PR TITLE
[BUG] Removed margin from footer

### DIFF
--- a/Client/src/Components/footer.jsx
+++ b/Client/src/Components/footer.jsx
@@ -8,7 +8,6 @@ const FooterContainer = styled.footer`
   position: relative;
   background-color: #3B82F6;
   padding: 1rem;
-  margin-top: 1rem;
   width: 100%;
   box-sizing: border-box;
 `;


### PR DESCRIPTION
The margin-top previously in place was causing issues for pages that have images for their backgrounds.

## Examples:
![image](https://github.com/user-attachments/assets/2bd9589e-c9aa-4966-aad3-93f537f7faaf)
![image](https://github.com/user-attachments/assets/b30d8368-2a81-438e-9a57-1261bea20869)

